### PR TITLE
New: Support use of `globalThis.location`

### DIFF
--- a/src/__tests__/window-history.test.ts
+++ b/src/__tests__/window-history.test.ts
@@ -55,3 +55,21 @@ describe("window.history", () => {
 		});
 	});
 });
+
+describe("globalThis.history", () => {
+	describe("replaceState()", () => {
+		it("should update location mock", () => {
+			expect(globalThis.location.pathname).toEqual("/");
+			globalThis.history.replaceState(null, "", "/0e37bca8-b8e3-49ee-8ac6-57e50c2884d3");
+			expect(globalThis.location.pathname).toEqual("/0e37bca8-b8e3-49ee-8ac6-57e50c2884d3");
+		});
+	});
+
+	describe("pushState()", () => {
+		it("should update location mock", () => {
+			expect(globalThis.location.pathname).toEqual("/");
+			globalThis.history.pushState(null, "", "/e8bf1e04-46e9-4f30-abcb-320412243ea2");
+			expect(globalThis.location.pathname).toEqual("/e8bf1e04-46e9-4f30-abcb-320412243ea2");
+		});
+	});
+});

--- a/src/hooks/__tests__/replace-location.test.ts
+++ b/src/hooks/__tests__/replace-location.test.ts
@@ -27,6 +27,18 @@ describe("window.location property descriptor", () => {
 	});
 });
 
+describe("globalThis.location property descriptor", () => {
+	describe("setter", () => {
+		it("should allow setting the href via the window.location setter", () => {
+			expect(globalThis.location.href).toEqual("http://localhost/");
+			// TypeScript's built-in lib is confused about the type of the `window.location` setter
+			globalThis.location = "http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
+			expect(globalThis.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
+			expect(globalThis.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+		});
+	});
+});
+
 describe("window proxy", () => {
 	it("should reflect non-location properties", () => {
 		// Has properties
@@ -73,5 +85,55 @@ describe("window proxy", () => {
 
 		// Get own keys
 		expect(Object.getOwnPropertyNames(window)).toEqual(expect.any(Array));
+	});
+});
+
+
+describe("globalThis proxy", () => {
+	it("should reflect non-location properties", () => {
+		// Has properties
+		expect(globalThis.open).toEqual(expect.any(Function));
+
+		// Can set and unset properties
+		expect(globalThis.onclick).toEqual(null);
+		const clickHandler = jest.fn();
+		// eslint-disable-next-line unicorn/prefer-add-event-listener
+		globalThis.onclick = clickHandler;
+		expect(globalThis.onclick).toEqual(clickHandler);
+		// eslint-disable-next-line unicorn/prefer-add-event-listener
+		globalThis.onclick = null;
+		expect(globalThis.onclick).toEqual(null);
+
+		// Can define properties that don't exist on the original window object
+		expect((globalThis as {customProperty?: string}).customProperty).toEqual(undefined);
+		Object.defineProperty(globalThis, "customProperty", {
+			value: "33147d34-3514-402e-85af-dd32e3c10882",
+			configurable: true,
+			writable: true,
+		});
+		expect((globalThis as {customProperty?: string}).customProperty).toEqual("33147d34-3514-402e-85af-dd32e3c10882");
+
+		// Get own property descriptor
+		expect(Object.getOwnPropertyDescriptor(globalThis, "customProperty")).toEqual({
+			value: "33147d34-3514-402e-85af-dd32e3c10882",
+			configurable: true,
+			writable: true,
+			enumerable: false,
+		});
+
+		// Delete properties
+		delete (globalThis as {customProperty?: string}).customProperty;
+
+		// Has properties
+		expect("onclick" in globalThis).toEqual(true);
+
+		// Get prototype
+		expect(Object.getPrototypeOf(globalThis)).toEqual(expect.any(Object));
+
+		// Get extensibility
+		expect(Object.isExtensible(globalThis)).toEqual(true);
+
+		// Get own keys
+		expect(Object.getOwnPropertyNames(globalThis)).toEqual(expect.any(Array));
 	});
 });

--- a/src/hooks/replace-location.ts
+++ b/src/hooks/replace-location.ts
@@ -41,8 +41,32 @@ export const replaceLocation = (): void => {
 			return Reflect.set(target, property, value);
 		},
 	});
+
+	const mockedGlobalThis = new Proxy(globalThis, {
+		get (target, property, receiver) {
+			if (property === "location") {
+				return locationMock;
+			}
+			return Reflect.get(target, property, receiver) as unknown;
+		},
+		set (target, property, value) {
+			if (property === "location") {
+				locationMock.href = value as string;
+				return true;
+			}
+			// Cannot add `receiver` argument or it will always return false as if it's non configurable
+			return Reflect.set(target, property, value);
+		},
+	});
+
 	// I am unsure how long this internal property will work, but I cannot find any other way to shadow the
 	// unconfigurable `window.location` property in JSDOM v21+
 	// https://github.com/jsdom/jsdom/blob/57bbf9a5c2bd32d3c811068480dee3cc8da3dd34/lib/jsdom/browser/Window.js#L54-L60
 	(window as {_globalProxy?: Window})._globalProxy = mockedWindow;
+	// Shadow `globalThis`
+	// - Cannot define property `location` on `globalThis` directly since it's non-configurable
+	// - Cannot assign `globalThis` to a new object since it's non-writable
+	Object.defineProperty(globalThis, "globalThis", {
+		value: mockedGlobalThis,
+	});
 };


### PR DESCRIPTION
 We're only able to shadow `window.location` by abusing an internal JSDOM property ever since JSDOM v21.

https://github.com/evelynhathaway/jest-location-mock/blob/47a557528e25e62bb088b6be3fbee17cfb302845/src/hooks/replace-location.ts#L44-L47

It appears that `window._globalProxy` does not affect `globalThis` like it does `window`, and `window._globalObject` doesn't appear to directly affect either. ([JSDOM source](https://github.com/jsdom/jsdom/blob/d312832b344c8055c0d61e55bacd1a675ad5826e/lib/jsdom/browser/Window.js#L58-L61)).

So, to shadow `globalThis`, we have to define `globalThis.globalThis` with the mock to shadow it.

Fixes #197