### PR TITLE
Fix: Make URLs absolute even if they are set via `window.location` setter

### DIFF
--- a/src/hooks/__tests__/replace-location.test.ts
+++ b/src/hooks/__tests__/replace-location.test.ts
@@ -17,24 +17,48 @@ describe("host environment variable", () => {
 
 describe("window.location property descriptor", () => {
 	describe("setter", () => {
-		it("should allow setting the href via the window.location setter", () => {
-			expect(window.location.href).toEqual("http://localhost/");
-			// TypeScript's built-in lib is confused about the type of the `window.location` setter
-			window.location = "http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
-			expect(window.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
-			expect(window.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+		describe("relative URL", () => {
+			it("should allow setting the href via the window.location setter", () => {
+				expect(window.location.href).toEqual("http://localhost/");
+				// TypeScript's built-in lib is confused about the type of the `window.location` setter
+				window.location = "/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
+				expect(window.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
+				expect(window.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+			});
+		});
+
+		describe("absolute URL", () => {
+			it("should allow setting the href via the window.location setter", () => {
+				expect(window.location.href).toEqual("http://localhost/");
+				// TypeScript's built-in lib is confused about the type of the `window.location` setter
+				window.location = "http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
+				expect(window.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
+				expect(window.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+			});
 		});
 	});
 });
 
 describe("globalThis.location property descriptor", () => {
 	describe("setter", () => {
-		it("should allow setting the href via the window.location setter", () => {
-			expect(globalThis.location.href).toEqual("http://localhost/");
-			// TypeScript's built-in lib is confused about the type of the `window.location` setter
-			globalThis.location = "http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
-			expect(globalThis.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
-			expect(globalThis.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+		describe("relative URL", () => {
+			it("should allow setting the href via the globalThis.location setter", () => {
+				expect(globalThis.location.href).toEqual("http://localhost/");
+				// TypeScript's built-in lib is confused about the type of the `globalThis.location` setter
+				globalThis.location = "/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
+				expect(globalThis.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
+				expect(globalThis.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+			});
+		});
+
+		describe("absolute URL", () => {
+			it("should allow setting the href via the globalThis.location setter", () => {
+				expect(globalThis.location.href).toEqual("http://localhost/");
+				// TypeScript's built-in lib is confused about the type of the `globalThis.location` setter
+				globalThis.location = "http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e" as unknown as Location & string;
+				expect(globalThis.location.href).toEqual("http://localhost/04ec3193-4942-4da4-92bf-5d807ec3907e");
+				expect(globalThis.location.pathname).toEqual("/04ec3193-4942-4da4-92bf-5d807ec3907e");
+			});
 		});
 	});
 });

--- a/src/hooks/replace-location.ts
+++ b/src/hooks/replace-location.ts
@@ -1,5 +1,5 @@
 import {jest} from "@jest/globals";
-import {LocationMockRelative} from "../utils";
+import {LocationMockRelative, makeAbsolute} from "../utils";
 import {getHost} from "../utils/get-host";
 
 export const originalLocationRef: {current: Location | null} = {current: null};
@@ -34,7 +34,7 @@ export const replaceLocation = (): void => {
 		},
 		set (target, property, value) {
 			if (property === "location") {
-				locationMock.href = value as string;
+				locationMock.href = makeAbsolute(value as string, locationMock.origin);
 				return true;
 			}
 			// Cannot add `receiver` argument or it will always return false as if it's non configurable
@@ -51,7 +51,7 @@ export const replaceLocation = (): void => {
 		},
 		set (target, property, value) {
 			if (property === "location") {
-				locationMock.href = value as string;
+				locationMock.href = makeAbsolute(value as string, locationMock.origin);
 				return true;
 			}
 			// Cannot add `receiver` argument or it will always return false as if it's non configurable

--- a/src/utils/location-mock-relative.ts
+++ b/src/utils/location-mock-relative.ts
@@ -1,14 +1,12 @@
 import {LocationMock} from "@jedmao/location";
 
+export const makeAbsolute = (url: string, origin: string) => new URL(url, origin).href;
 
 export class LocationMockRelative extends LocationMock implements Location {
 	assign (url: string): void {
-		super.assign(this.makeAbsolute(url));
+		super.assign(makeAbsolute(url, this.origin));
 	}
 	replace (url: string): void {
-		super.replace(this.makeAbsolute(url));
-	}
-	private makeAbsolute (url: string) {
-		return new URL(url, this.origin).href;
+		super.replace(makeAbsolute(url, this.origin));
 	}
 }


### PR DESCRIPTION
Fixes #198